### PR TITLE
Fix cmp option typo

### DIFF
--- a/modules/applications/neovim.nix
+++ b/modules/applications/neovim.nix
@@ -149,7 +149,7 @@ in
                 enable = dev;
                 settings = {
                   performance = {
-                    max_view_entires = 80; # default: 200
+                    max_view_entries = 80; # default: 200
                   };
                   sources = [
                     { name = "nvim_lsp"; }


### PR DESCRIPTION
## Summary
- fix a typo in cmp's performance option

## Testing
- `nix flake show` *(fails: operation canceled due to heavy network usage)*

------
https://chatgpt.com/codex/tasks/task_e_684156b1ce08832dab40fe35e70dcc55