### PR TITLE
Update nebula hostnames

### DIFF
--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -8,8 +8,18 @@
 {
   flake =
     let
-      specialArgs = {
-        inherit self inputs vars;
+      baseArgs = { inherit self inputs vars; };
+      homeServerSystem = lib.nixosSystem {
+        specialArgs = baseArgs;
+        modules = [
+          self.nixosModules.host-oreamnos
+          inputs.srvos.nixosModules.server
+          inputs.srvos.nixosModules.mixins-nix-experimental
+        ];
+      };
+      homeServerDomains = builtins.attrNames homeServerSystem.config.services.nginx.virtualHosts;
+      specialArgs = baseArgs // {
+        vars = baseArgs.vars // { inherit homeServerDomains; };
       };
     in
     {

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -19,7 +19,9 @@
       };
       homeServerDomains = builtins.attrNames homeServerSystem.config.services.nginx.virtualHosts;
       specialArgs = baseArgs // {
-        vars = baseArgs.vars // { inherit homeServerDomains; };
+        vars = baseArgs.vars // {
+          inherit homeServerDomains;
+        };
       };
     in
     {

--- a/modules/home-server/default.nix
+++ b/modules/home-server/default.nix
@@ -1,4 +1,7 @@
-{ lib, inputs, ... }:
+{ lib, inputs, config, ... }:
+let
+  cfg = config.sifr.home-server;
+in
 {
   imports = [
     inputs.authentik-nix.nixosModules.default
@@ -19,5 +22,17 @@
 
   options.sifr.home-server = {
     enable = lib.mkEnableOption "home server setup";
+    domains = lib.mkOption {
+      type = with lib.types; listOf str;
+      readOnly = true;
+      default = [];
+      description = "Domains served by the home server web instance.";
+    };
+  };
+
+  config = {
+    sifr.home-server.domains = lib.mkIf cfg.enable (
+      builtins.attrNames config.services.nginx.virtualHosts
+    );
   };
 }

--- a/modules/home-server/default.nix
+++ b/modules/home-server/default.nix
@@ -1,4 +1,9 @@
-{ lib, inputs, config, ... }:
+{
+  lib,
+  inputs,
+  config,
+  ...
+}:
 let
   cfg = config.sifr.home-server;
 in
@@ -25,7 +30,7 @@ in
     domains = lib.mkOption {
       type = with lib.types; listOf str;
       readOnly = true;
-      default = [];
+      default = [ ];
       description = "Domains served by the home server web instance.";
     };
   };

--- a/modules/networking/nebula.nix
+++ b/modules/networking/nebula.nix
@@ -62,13 +62,7 @@ in
       "10.10.0.12" = [
         "oreamnos"
         "oreamnos.alq"
-        "alq.ae"
-        "vault.alq.ae"
-        "git.alq.ae"
-        "yt.alq.ae"
-        "sdr.alq.ae"
-        "tv.alq.ae"
-      ];
+      ] ++ vars.homeServerDomains;
       "10.10.0.13" = [
         "duisk"
         "duisk.alq"


### PR DESCRIPTION
## Summary
- derive `homeServerDomains` from home web server configuration
- use that to populate Nebula host list for 10.10.0.12

## Testing
- `nix fmt`
- `nix flake check` *(failed: interrupted by the user)*

------
https://chatgpt.com/codex/tasks/task_e_6842791b0624832d895f61ef92020b3c